### PR TITLE
feat: Add placeholder public directory and index.html

### DIFF
--- a/whorang/Dockerfile
+++ b/whorang/Dockerfile
@@ -83,6 +83,9 @@ RUN npm rebuild better-sqlite3 canvas
 # Copy source code
 COPY . .
 
+# Copy public directory
+COPY public /app/public
+
 # Copy nginx configuration files
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY backend.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This commit adds a placeholder `public` directory with an `index.html` file to the `whorang` backend. This resolves an issue where the server would crash on startup due to a missing `index.html` file.

The `Dockerfile` has been updated to copy the `public` directory into the Docker image.