### PR TITLE
Fix permissions in docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -144,7 +144,7 @@ jobs:
           # Prepare writable data directories
           mkdir -p /tmp/whorang-standalone-data /tmp/whorang-addon-data
           chmod 755 /tmp/whorang-standalone-data /tmp/whorang-addon-data
-          chown root:root /tmp/whorang-standalone-data /tmp/whorang-addon-data
+          sudo chown root:root /tmp/whorang-standalone-data /tmp/whorang-addon-data
 
           # Create minimal Home Assistant options file for addon mode detection
           cat > /tmp/whorang-addon-data/options.json <<'EOF'


### PR DESCRIPTION
## Summary
- ensure the test job can change directory ownership by using sudo

## Testing
- `bash final-verification.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0950d82c832fa568bd6df1a3b28c